### PR TITLE
fix: Resolve PSD calculation error

### DIFF
--- a/fpv_tuner/analysis/noise.py
+++ b/fpv_tuner/analysis/noise.py
@@ -52,7 +52,8 @@ def calculate_psd(data_series, time_series_us, nperseg=256):
 
     # Welch's method for a cleaner spectrum
     try:
-        frequencies, psd = welch(data, fs, nperseg=nperseg)
+        # Convert pandas Series to NumPy array for max compatibility with scipy
+        frequencies, psd = welch(data.values, fs, nperseg=nperseg)
         return frequencies, psd
     except Exception as e:
         print(f"Error calculating PSD: {e}")


### PR DESCRIPTION
This commit fixes a warning/error that occurred during the Power Spectral Density (PSD) calculation in the Noise Analysis tab.

The error ('key of type tuple not found and not a MultiIndex') was caused by an incompatibility between the pandas Series object and the `scipy.signal.welch` function in some cases.

The fix is to explicitly convert the data Series to a NumPy array using `.values` before passing it to the `welch` function. This ensures maximum compatibility and resolves the issue.