### PR TITLE
fix: Add missing QTextEdit import in StepResponseTab

### DIFF
--- a/fpv_tuner/gui/step_response_tab.py
+++ b/fpv_tuner/gui/step_response_tab.py
@@ -1,7 +1,7 @@
 import os
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QComboBox, QLabel,
-    QDoubleSpinBox, QFormLayout, QSpinBox
+    QDoubleSpinBox, QFormLayout, QSpinBox, QTextEdit
 )
 import pyqtgraph as pg
 import numpy as np


### PR DESCRIPTION
This commit fixes a `NameError` crash that occurred when initializing the application. The `QTextEdit` widget was used in the Step Response tab to display metrics, but it was not imported from `PyQt6.QtWidgets`.

The missing import has been added, resolving the crash.