### PR TITLE
debug: Add diagnostic logging to step detection

### DIFF
--- a/fpv_tuner/analysis/system_identification.py
+++ b/fpv_tuner/analysis/system_identification.py
@@ -34,24 +34,28 @@ def second_order_step_model(t, K, wn, zeta):
 # ------------------------------
 # Main Analysis Function
 # ------------------------------
-def analyze_axis_response(time, rc_command, gyro_response, threshold_ratio=0.7):
+def analyze_axis_response(axis_name, time, rc_command, gyro_response, threshold_ratio=0.7):
     """
     Analyzes a single axis to find the average, normalized step response and fit system models.
     Returns a dictionary with analysis results.
     """
+    print(f"\n--- Analyzing {axis_name} ---")
     dt = np.mean(np.diff(time))
     if np.isnan(dt) or dt == 0:
         return {"error": "Invalid time data"}
 
     # --- Step 1: Detect large deflections ---
     max_rc = np.max(np.abs(rc_command))
+    print(f"Max RC command: {max_rc:.2f}")
     if max_rc == 0:
         return {"error": "No RC command input"}
 
     thresh = threshold_ratio * max_rc
+    print(f"Detection threshold: {thresh:.2f}")
     deflex_mask = np.abs(rc_command) > thresh
     # Find indices where the mask goes from False to True
     starts = np.where(np.diff(deflex_mask.astype(int)) == 1)[0]
+    print(f"Found {len(starts)} potential step starts.")
 
     if len(starts) == 0:
         return {"error": f"No deflections found above threshold {thresh:.0f}"}

--- a/fpv_tuner/gui/step_response_tab.py
+++ b/fpv_tuner/gui/step_response_tab.py
@@ -107,7 +107,7 @@ class StepResponseTab(QWidget):
             rc_data = log_data[rc_col].to_numpy()
             gyro_data = log_data[gyro_col].to_numpy()
 
-            results = analyze_axis_response(time_data, rc_data, gyro_data, threshold_ratio)
+            results = analyze_axis_response(axis_name, time_data, rc_data, gyro_data, threshold_ratio)
 
             full_metrics_text += f"--- {axis_name} ---\n"
             if "error" in results:


### PR DESCRIPTION
This commit adds detailed print statements to the `analyze_axis_response` function in the system identification module.

It logs the following intermediate values for each axis:
- Max RC command value
- Calculated detection threshold
- Number of potential step starts found

This will help diagnose issues with the step detection algorithm on real-world log data where no steps are currently being found.