### PR TITLE
feat: Overhaul analysis tabs and add Spectrogram view

### DIFF
--- a/fpv_tuner/analysis/noise.py
+++ b/fpv_tuner/analysis/noise.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from scipy.signal import welch
+from scipy.signal import welch, spectrogram
 
 def get_sampling_frequency(time_series_us):
     """
@@ -85,3 +85,25 @@ def calculate_signal_stats(data_series, frequencies, psd):
         stats["Max Noise Peak"] = f"{max_noise_freq:.1f} Hz"
 
     return stats
+
+def calculate_spectrogram(data_series, time_series_us, nperseg=256):
+    """
+    Calculates the Spectrogram of a signal.
+    """
+    if data_series is None or data_series.empty:
+        return None, None, None
+
+    # Remove any NaN values that would crash the calculation
+    data = data_series.dropna()
+    if data.empty:
+        return None, None, None
+
+    fs = get_sampling_frequency(time_series_us)
+
+    try:
+        # Using .values to ensure it's a NumPy array
+        frequencies, times, Sxx = spectrogram(data.values, fs, nperseg=nperseg)
+        return frequencies, times, Sxx
+    except Exception as e:
+        print(f"Error calculating spectrogram: {e}")
+        return None, None, None

--- a/fpv_tuner/gui/noise_tab.py
+++ b/fpv_tuner/gui/noise_tab.py
@@ -1,12 +1,13 @@
 import os
 import numpy as np
 from PyQt6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QCheckBox, QGridLayout, QLabel,
-    QListWidget, QListWidgetItem, QComboBox, QFormLayout
+    QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, QLabel,
+    QListWidget, QListWidgetItem, QComboBox, QFormLayout, QPushButton,
+    QStackedWidget, QTextEdit
 )
 from PyQt6.QtCore import Qt
 import pyqtgraph as pg
-from fpv_tuner.analysis.noise import calculate_psd
+from fpv_tuner.analysis.noise import calculate_psd, calculate_spectrogram, calculate_signal_stats
 
 class NoiseTab(QWidget):
     SIGNAL_MAP = {
@@ -26,6 +27,7 @@ class NoiseTab(QWidget):
     def __init__(self):
         super().__init__()
         self.logs = {}
+        self.is_psd_mode = True
 
         main_layout = QHBoxLayout(self)
         controls_layout = QVBoxLayout()
@@ -34,21 +36,21 @@ class NoiseTab(QWidget):
         main_layout.addLayout(plots_layout, 3)
 
         # --- Controls ---
-        # nperseg ComboBox
         nperseg_layout = QFormLayout()
         self.nperseg_combo = QComboBox()
         self.nperseg_combo.addItems(["256", "512", "1024", "2048", "4096"])
         self.nperseg_combo.setCurrentText("1024")
-        nperseg_layout.addRow("PSD Resolution (NPERSEG):", self.nperseg_combo)
+        nperseg_layout.addRow("PSD/DSA Resolution:", self.nperseg_combo)
         controls_layout.addLayout(nperseg_layout)
 
-        # Signal List
+        self.view_toggle_button = QPushButton("Show Spectrogram (DSA)")
+        controls_layout.addWidget(self.view_toggle_button)
+
         controls_layout.addWidget(QLabel("Signals:"))
         self.signal_list = QListWidget()
         for signal_name in self.SIGNAL_MAP.keys():
             item = QListWidgetItem(signal_name)
             item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
-            # Default to showing Gyro Roll
             if "Gyro (Raw) - Roll" in signal_name:
                  item.setCheckState(Qt.CheckState.Checked)
             else:
@@ -57,101 +59,142 @@ class NoiseTab(QWidget):
 
         controls_layout.addWidget(self.signal_list)
 
-        # Stats Display
-        controls_layout.addWidget(QLabel("Signal Statistics:"))
+        controls_layout.addWidget(QLabel("Signal Statistics (PSD Mode):"))
         self.stats_text = QTextEdit()
         self.stats_text.setReadOnly(True)
         self.stats_text.setFontFamily("monospace")
-        self.stats_text.setFixedHeight(100) # Give it a fixed height
+        self.stats_text.setFixedHeight(100)
         controls_layout.addWidget(self.stats_text)
-
         controls_layout.addStretch()
+
+        # --- Plots ---
+        self.trace_plot = pg.PlotWidget(title="Time Series Trace")
+        self.trace_plot.addLegend()
+        self.trace_plot.setDownsampling(auto=True, mode='peak')
+        self.trace_plot.setClipToView(True)
+
+        self.psd_plot = pg.PlotWidget(title="Power Spectral Density (PSD)")
+        self.psd_plot.addLegend()
+        self.psd_plot.setLogMode(x=True, y=True)
+        self.psd_plot.setLabel('bottom', 'Frequency (Hz)')
+        self.psd_plot.setLabel('left', 'Power/Frequency (dB/Hz)')
+
+        self.spectrogram_view = pg.ImageView()
+        self.spectrogram_view.getView().setLabel('bottom', 'Time (s)')
+        self.spectrogram_view.getView().setLabel('left', 'Frequency (Hz)')
+
+        self.plot_stack = QStackedWidget()
+        self.plot_stack.addWidget(self.psd_plot)
+        self.plot_stack.addWidget(self.spectrogram_view)
+
+        plots_layout.addWidget(self.trace_plot)
+        plots_layout.addWidget(self.plot_stack)
 
         # --- Connections ---
         self.nperseg_combo.currentTextChanged.connect(self.update_plots)
         self.signal_list.itemChanged.connect(self.update_plots)
-
-        # --- Plots ---
-        self.trace_plot = pg.PlotWidget(title="Time Series Trace")
-        self.psd_plot = pg.PlotWidget(title="Power Spectral Density (PSD)")
-        self.trace_plot.addLegend()
-        self.psd_plot.addLegend()
-        self.trace_plot.setDownsampling(auto=True, mode='peak')
-        self.trace_plot.setClipToView(True)
-        self.psd_plot.setLogMode(x=True, y=True)
-        self.psd_plot.setLabel('bottom', 'Frequency (Hz)')
-        self.psd_plot.setLabel('left', 'Power/Frequency (dB/Hz)')
-        plots_layout.addWidget(self.trace_plot)
-        plots_layout.addWidget(self.psd_plot)
+        self.view_toggle_button.clicked.connect(self.on_toggle_view_clicked)
 
     def set_data(self, logs):
         self.logs = logs
         self.update_plots()
 
     def update_plots(self):
+        # Clear all plots and stats first
         self.trace_plot.clear()
         self.psd_plot.clear()
+        self.spectrogram_view.clear()
         self.stats_text.clear()
 
         if not self.logs:
             return
 
-        checked_signals = []
-        for i in range(self.signal_list.count()):
-            item = self.signal_list.item(i)
-            if item.checkState() == Qt.CheckState.Checked:
-                checked_signals.append(item.text())
+        checked_signals = [self.signal_list.item(i).text() for i in range(self.signal_list.count()) if self.signal_list.item(i).checkState() == Qt.CheckState.Checked]
 
         if not checked_signals:
             return
 
         nperseg = int(self.nperseg_combo.currentText())
-
-        color_index = 0
-        full_stats_text = ""
-
         filename, log_data = next(iter(self.logs.items()))
 
         time_col = self._find_column(log_data, ['time (us)', 'time'])
         if not time_col:
             return
-
         time_us = log_data[time_col]
         time_s = time_us / 1_000_000
 
-        for signal_name in checked_signals:
+        # --- PSD Mode ---
+        if self.is_psd_mode:
+            self.trace_plot.addLegend()
+            self.psd_plot.addLegend()
+            full_stats_text = ""
+            for i, signal_name in enumerate(checked_signals):
+                possible_names = self.SIGNAL_MAP.get(signal_name)
+                if not possible_names: continue
+
+                col_name = self._find_column(log_data, possible_names)
+                if col_name:
+                    color = self.PLOT_COLORS[i % len(self.PLOT_COLORS)]
+                    pen = pg.mkPen(color=color)
+                    signal_data = log_data[col_name]
+
+                    self.trace_plot.plot(time_s, signal_data, pen=pen, name=signal_name)
+                    freq, psd = calculate_psd(signal_data, time_us, nperseg=nperseg)
+
+                    stats = {}
+                    if freq is not None and psd is not None and len(freq) > 0 and len(psd) > 0:
+                        psd_db = 10 * np.log10(psd + 1e-12)
+                        self.psd_plot.plot(freq, psd_db, pen=pen, name=f"{signal_name} PSD")
+                        stats = calculate_signal_stats(signal_data, freq, psd)
+                    else:
+                        stats = calculate_signal_stats(signal_data, None, None)
+
+                    full_stats_text += f"--- {signal_name} ---\n"
+                    for key, value in stats.items():
+                        full_stats_text += f"  {key}: {value}\n"
+                    full_stats_text += "\n"
+
+            self.stats_text.setText(full_stats_text)
+
+        # --- Spectrogram Mode ---
+        else:
+            self.trace_plot.addLegend(None) # Hide legend
+            self.psd_plot.clear()
+
+            # Use first selected signal for spectrogram
+            signal_name = checked_signals[0]
             possible_names = self.SIGNAL_MAP.get(signal_name)
-            if not possible_names:
-                continue
+            if not possible_names: return
 
             col_name = self._find_column(log_data, possible_names)
-
             if col_name:
-                color = self.PLOT_COLORS[color_index % len(self.PLOT_COLORS)]
-                pen = pg.mkPen(color=color, style=Qt.PenStyle.SolidLine)
-
                 signal_data = log_data[col_name]
-                self.trace_plot.plot(time_s, signal_data, pen=pen, name=signal_name)
+                self.trace_plot.plot(time_s, signal_data, pen='w', name=signal_name)
 
-                freq, psd = calculate_psd(signal_data, time_us, nperseg=nperseg)
+                freqs, times, Sxx = calculate_spectrogram(signal_data, time_us, nperseg=nperseg)
 
-                stats = {}
-                if freq is not None and len(freq) > 0 and psd is not None and len(psd) > 0:
-                    psd_db = 10 * np.log10(psd)
-                    self.psd_plot.plot(freq, psd_db, pen=pen, name=f"{signal_name} PSD")
-                    stats = calculate_signal_stats(signal_data, freq, psd)
-                else: # Still calculate time-domain stats even if PSD fails
-                    stats = calculate_signal_stats(signal_data, None, None)
+                if freqs is not None and times is not None and Sxx is not None:
+                    # Log scale for better color visualization
+                    Sxx_log = np.log10(Sxx + 1e-12) # Add epsilon to avoid log(0)
 
-                # Format stats for this signal
-                full_stats_text += f"--- {signal_name} ---\n"
-                for key, value in stats.items():
-                    full_stats_text += f"  {key}: {value}\n"
-                full_stats_text += "\n"
+                    # pyqtgraph ImageView needs a transform to set the axes scales correctly
+                    tr = pg.QtGui.QTransform()
+                    tr.scale(times[-1] / Sxx.shape[1], freqs[-1] / Sxx.shape[0])
+                    self.spectrogram_view.setImage(Sxx_log.T, autoRange=False, transform=tr)
+                    self.spectrogram_view.getView().setTitle(f"Spectrogram - {signal_name}")
 
-                color_index += 1
+    def on_toggle_view_clicked(self):
+        self.is_psd_mode = not self.is_psd_mode
+        if self.is_psd_mode:
+            self.plot_stack.setCurrentWidget(self.psd_plot)
+            self.view_toggle_button.setText("Show Spectrogram (DSA)")
+            self.stats_text.setVisible(True)
+        else:
+            self.plot_stack.setCurrentWidget(self.spectrogram_view)
+            self.view_toggle_button.setText("Show PSD")
+            self.stats_text.setVisible(False) # Stats are for PSD only
 
-        self.stats_text.setText(full_stats_text)
+        self.update_plots()
 
     def _find_column(self, df, possible_names):
         for name in possible_names:


### PR DESCRIPTION
This commit introduces a major set of improvements to the Step Response and Noise Analysis tabs.

Step Response:
- Replaces analysis logic with a new method that calculates direct metrics.
- Adds interactive controls for `threshold` and `std_dev_max`.
- Implements an "Auto-Tune" button to suggest optimal parameters.

Noise Analysis:
- Replaces the UI with a single multi-select list for all signals.
- Adds a dropdown to control the NPERSEG parameter for PSD resolution.
- Adds a new backend function and frontend display for signal statistics.
- Implements a new Spectrogram (DSA) view with a toggle button to switch from the PSD plot.