### PR TITLE
fix(ui): Correct method for setting spectrogram labels

### DIFF
--- a/fpv_tuner/gui/noise_tab.py
+++ b/fpv_tuner/gui/noise_tab.py
@@ -80,8 +80,9 @@ class NoiseTab(QWidget):
         self.psd_plot.setLabel('left', 'Power/Frequency (dB/Hz)')
 
         self.spectrogram_view = pg.ImageView()
-        self.spectrogram_view.getView().setLabel('bottom', 'Time (s)')
-        self.spectrogram_view.getView().setLabel('left', 'Frequency (Hz)')
+        # Use getPlotItem() to access the axes and set labels
+        self.spectrogram_view.getPlotItem().setLabel('bottom', 'Time (s)')
+        self.spectrogram_view.getPlotItem().setLabel('left', 'Frequency (Hz)')
 
         self.plot_stack = QStackedWidget()
         self.plot_stack.addWidget(self.psd_plot)


### PR DESCRIPTION
Corrects an `AttributeError` that crashed the application on startup when creating the Noise Analysis tab.

The `setLabel` method must be called on the `PlotItem` of the `ImageView`, not on its `ViewBox`. Changed `.getView().setLabel()` to `.getPlotItem().setLabel()`.