### PR TITLE
fix(ui): Correctly initialize ImageView with a custom PlotItem

### DIFF
--- a/fpv_tuner/gui/noise_tab.py
+++ b/fpv_tuner/gui/noise_tab.py
@@ -79,10 +79,10 @@ class NoiseTab(QWidget):
         self.psd_plot.setLabel('bottom', 'Frequency (Hz)')
         self.psd_plot.setLabel('left', 'Power/Frequency (dB/Hz)')
 
-        self.spectrogram_view = pg.ImageView()
-        # Use the .plotItem attribute to access the axes and set labels
-        self.spectrogram_view.plotItem.setLabel('bottom', 'Time (s)')
-        self.spectrogram_view.plotItem.setLabel('left', 'Frequency (Hz)')
+        spectrogram_plot_item = pg.PlotItem()
+        spectrogram_plot_item.setLabel('bottom', 'Time (s)')
+        spectrogram_plot_item.setLabel('left', 'Frequency (Hz)')
+        self.spectrogram_view = pg.ImageView(view=spectrogram_plot_item)
 
         self.plot_stack = QStackedWidget()
         self.plot_stack.addWidget(self.psd_plot)


### PR DESCRIPTION
Resolves a startup crash in the Noise Analysis tab by changing how the `ImageView` widget is created.

Instead of trying to modify the `ImageView`'s labels after creation, a `PlotItem` is now created and configured with the correct labels first. This `PlotItem` is then passed to the `ImageView` constructor, which is the correct and documented approach. This prevents the `AttributeError`.