### PR TITLE
fix(core): Correct thread cleanup to prevent crash

### DIFF
--- a/fpv_tuner/gui/main_window.py
+++ b/fpv_tuner/gui/main_window.py
@@ -142,9 +142,9 @@ class MainWindow(QMainWindow):
         """
         self.open_action.setEnabled(True)
         self.statusBar().showMessage("Ready", 3000)
-        # It's good practice to nullify the thread/worker after they are done
-        self.thread = None
-        self.worker = None
+        # self.thread and self.worker will be cleaned up by the thread.finished
+        # signal connected to deleteLater. Manually nullifying them here can
+        # cause a race condition with the garbage collector.
 
     def remove_selected_logs(self):
         for i in reversed(range(self.log_list_widget.count())):


### PR DESCRIPTION
Removes manual nullification of thread and worker objects in `on_all_loads_finished`.

Setting the references to None created a race condition between the Python garbage collector and Qt's `deleteLater` mechanism, causing a SIGABRT crash. The existing connection to `deleteLater` is sufficient for safe, asynchronous object cleanup.