### PR TITLE
feat: Enhance tuning analysis with response classification

### DIFF
--- a/fpv_tuner/analysis/tuning.py
+++ b/fpv_tuner/analysis/tuning.py
@@ -344,7 +344,7 @@ def generate_cli(pids):
     return cli_commands
 
 
-def simulate_step_response(pids, axis, inertia=0.005, duration=0.2, time_steps=500, noise_level=0.0,
+def simulate_step_response(pids, axis, inertia=0.005, duration=1.0, time_steps=1000, noise_level=0.0,
                          disturbance_magnitude=0.0, disturbance_time=0.0):
     """
     Simulates the step response of a PID controller using a discrete-time loop.
@@ -510,3 +510,28 @@ def calculate_response_metrics(time, response, setpoint=1.0):
         "Settling Time (s)": settling_time,
         "Oscillation": oscillation
     }
+
+
+def classify_step_response(metrics):
+    """
+    Analyzes response metrics to classify the system's behavior.
+    Returns a text description and a color hint.
+    """
+    if not metrics or any(np.isnan(v) for v in metrics.values()):
+        return "Unstable or Incomplete", "red"
+
+    overshoot = metrics.get("Overshoot (%)", 0)
+    oscillation = metrics.get("Oscillation", 0)
+    rise_time = metrics.get("Rise Time (s)", 1.0)
+
+    if overshoot > 15 or oscillation > 10:
+        return "Oscillatory / High Overshoot", "red"
+    elif overshoot > 5:
+        return "Underdamped (noticeable overshoot)", "orange"
+    elif overshoot >= 0:
+        if rise_time < 0.08:
+             return "Critically Damped (Optimal)", "green"
+        else:
+             return "Slightly Overdamped (Slow)", "yellow"
+    else: # Overshoot is negative
+        return "Overdamped (Very Sluggish)", "blue"


### PR DESCRIPTION
This commit implements several user-requested enhancements to the PID Tuning tab to improve the analysis of simulation results.

1.  **Backend (`fpv_tuner/analysis/tuning.py`):**
    - A new function `classify_step_response` has been added. It takes a dictionary of performance metrics and returns a descriptive string and a color hint based on a set of heuristics (e.g., classifying based on overshoot and rise time).
    - The `simulate_step_response` function's default duration has been increased, and it now correctly accepts the `duration` parameter from the frontend.

2.  **Frontend (`fpv_tuner/gui/tuning_tab.py`):**
    - A new `QDoubleSpinBox` has been added to the UI, allowing the user to configure the simulation duration. This value is now passed to the simulation function.
    - New `QLabel`s have been added to the metrics section to display the text-based classification of both the current and proposed tunes.
    - A new helper method, `_update_classification_display`, applies the text and color from the classifier function to the new labels.
    - The line plotting the D-Term trace has been removed to clean up the graph.