### PR TITLE
feat: Add non-modal warnings and blackbox/cli version verification

### DIFF
--- a/fpv_tuner/analysis/blackbox_parser.py
+++ b/fpv_tuner/analysis/blackbox_parser.py
@@ -1,0 +1,27 @@
+def get_blackbox_headers(file_path):
+    """
+    Reads the first few lines of a decoded Blackbox CSV file to extract
+    key metadata headers.
+
+    Returns:
+        A dictionary containing the parsed header values.
+    """
+    headers = {}
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            # Read up to the first 20 lines, which should contain all headers
+            for _ in range(20):
+                line = f.readline().strip()
+                if not line:
+                    break
+
+                # Betaflight headers start with "H "
+                if line.startswith('H '):
+                    line = line[2:] # Remove the prefix
+                    if ':' in line:
+                        key, value = line.split(':', 1)
+                        headers[key.strip()] = value.strip()
+    except Exception as e:
+        print(f"Could not read blackbox headers from {file_path}: {e}")
+
+    return headers


### PR DESCRIPTION
This commit implements two user-requested features to improve the safety and user experience of the PID Tuning tab.

1.  **Warning System Overhaul:**
    - The `validate_settings` function in `tuning.py` has been refactored to accept `original_pids` and `proposed_pids`. It now primarily warns if a proposed PID is outside the 0.5x-1.7x range of the original value. The absolute checks against drone profile ranges are kept as a secondary safety net.
    - In `tuning_tab.py`, the `QMessageBox` for warnings has been removed. A new `QTextEdit` area has been added to display warnings in a non-interruptive manner. This area is shown or hidden dynamically.

2.  **Firmware Version Verification:**
    - A new parser, `fpv_tuner/analysis/blackbox_parser.py`, has been created to extract metadata headers from decoded Blackbox CSV files.
    - The `parse_dump` function in `tuning.py` has been enhanced to also extract the firmware version string.
    - The `TuningTab` GUI now has a "Load Blackbox CSV Log" button and a status label.
    - New logic has been added to the `TuningTab` to compare the firmware versions from the two loaded files and display a prominent, color-coded status message to the user.