### PR TITLE
fix: Add missing QSlider import in TuningTab

### DIFF
--- a/fpv_tuner/gui/tuning_tab.py
+++ b/fpv_tuner/gui/tuning_tab.py
@@ -3,7 +3,7 @@ import shutil
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QFormLayout, QTextEdit, QSpinBox, QPushButton,
     QFileDialog, QGroupBox, QLabel, QMessageBox, QCheckBox, QDoubleSpinBox, QGridLayout,
-    QComboBox
+    QComboBox, QSlider
 )
 from PyQt6.QtCore import Qt
 import pyqtgraph as pg


### PR DESCRIPTION
Resolves a `NameError` that occurred when initializing the TuningTab. The `QSlider` widget was used without being imported from `PyQt6.QtWidgets`.

This commit adds the necessary import statement, allowing the application to launch successfully.