### PR TITLE
fix: Correct argument for disabling interpolation in blackbox_decode

### DIFF
--- a/fpv_tuner/blackbox/loader.py
+++ b/fpv_tuner/blackbox/loader.py
@@ -58,7 +58,7 @@ def _decode_blackbox_log(file_path):
     except Exception as e:
         return None, None, f"Failed to create temporary directory: {e}"
 
-    command = ['blackbox_decode', file_path, '--output-dir', temp_dir, '--no-interpolation']
+    command = ['blackbox_decode', file_path, '--output-dir', temp_dir, '--no-interpolate']
 
     try:
         print(f"Running command: {' '.join(command)}")


### PR DESCRIPTION
Resolves a `CalledProcessError` during log decoding. The `blackbox_decode` executable was being called with `--no-interpolation`, which is an invalid argument.

Based on user-provided error messages and common command-line argument patterns, the correct flag is likely `--no-interpolate`. This commit makes that change.