### PR TITLE
fix: Remove flag from blackbox_decode to prevent crash

### DIFF
--- a/fpv_tuner/blackbox/loader.py
+++ b/fpv_tuner/blackbox/loader.py
@@ -58,7 +58,7 @@ def _decode_blackbox_log(file_path):
     except Exception as e:
         return None, None, f"Failed to create temporary directory: {e}"
 
-    command = ['blackbox_decode', file_path, '--output-dir', temp_dir, '--no-interpolate']
+    command = ['blackbox_decode', file_path, '--output-dir', temp_dir]
 
     try:
         print(f"Running command: {' '.join(command)}")


### PR DESCRIPTION
Removes the `--no-interpolate` flag from the `blackbox_decode` command.

This flag was causing a `CalledProcessError` on the user's system due to a version mismatch or other incompatibility with their installed `blackbox_decode` executable. The flag is not present in the official source code's documentation.

Removing the flag ensures the application does not crash and can successfully decode logs, with the minor trade-off that the data may be interpolated by default.