### PR TITLE
fix: Correct NameError and TypeError in tuning tab

### DIFF
--- a/fpv_tuner/analysis/tuning.py
+++ b/fpv_tuner/analysis/tuning.py
@@ -152,7 +152,11 @@ def validate_settings(proposed_pids, original_pids, drone_profile):
 
     # Relative (multiplier) checks
     for key in proposed_pids:
-        if key in original_pids and original_pids[key] > 0 and key.startswith(('p_', 'i_', 'd_')):
+        if key in original_pids and isinstance(original_pids[key], (int, float)) and original_pids[key] > 0 and key.startswith(('p_', 'i_', 'd_')):
+            # Ensure the proposed value is also a number before dividing
+            if not isinstance(proposed_pids[key], (int, float)):
+                continue
+
             ratio = proposed_pids[key] / original_pids[key]
             if not (0.5 <= ratio <= 1.7):
                 warnings.append(

--- a/fpv_tuner/gui/tuning_tab.py
+++ b/fpv_tuner/gui/tuning_tab.py
@@ -11,6 +11,7 @@ import pyqtgraph as pg
 from fpv_tuner.analysis.tuning import DRONE_PROFILES, parse_dump, tune_with_sliders, generate_cli, simulate_step_response, validate_settings, calculate_response_metrics, classify_step_response
 from fpv_tuner.analysis.blackbox_parser import get_blackbox_headers
 from fpv_tuner.blackbox.loader import _decode_blackbox_log
+from fpv_tuner.analysis.utils import apply_smoothing
 
 class TuningTab(QWidget):
     dump_filepath = None


### PR DESCRIPTION
This commit addresses two critical bugs reported by the user that caused crashes in the PID Tuning tab.

1.  **Resolves `NameError: name 'apply_smoothing' is not defined`**: The `apply_smoothing` function was being called in `fpv_tuner/gui/tuning_tab.py` without being imported. This commit adds the necessary import statement from `fpv_tuner.analysis.utils`.

2.  **Resolves `TypeError: '>' not supported between 'str' and 'int'`**: This error occurred in the `validate_settings` function in `fpv_tuner/analysis/tuning.py`. It was caused by attempting to perform a numerical comparison on a PID value that had been parsed as a string from the dump file. The fix makes the validation logic more robust by adding an `isinstance` check to ensure values are numeric before comparison, preventing the crash.